### PR TITLE
Delete _$folder$ files

### DIFF
--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -146,6 +146,11 @@ class S3Client(FileSystem):
         delete_key_list = [
             k for k in s3_bucket.list(self._add_path_delimiter(key))]
 
+        # delete the directory marker file if it exists
+        s3_dir_with_suffix_key = s3_bucket.get_key(key + S3_DIRECTORY_MARKER_SUFFIX_1)
+        if s3_dir_with_suffix_key:
+            delete_key_list.append(s3_dir_with_suffix_key)
+
         if len(delete_key_list) > 0:
             for k in delete_key_list:
                 logger.debug('Deleting %s from bucket %s', k, bucket)


### PR DESCRIPTION
@jeremykarn Can you take a look? 

When deleting an S3 "folder", we should delete the marker files that are used in S3 to simulate folders (_$folder$ files).