### PR TITLE
Fix bug where all classes were being required to override delete_where_clause

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -102,7 +102,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         return ''
 
-    @abc.abstractproperty
+    @property
     def delete_where_clause(self):
         """
         Override to return the where clause to use for deleting rows


### PR DESCRIPTION
Tested with https://gist.github.com/ddaniels888/113bde11982c491bba8f2ec98321846b